### PR TITLE
useDynLib issue

### DIFF
--- a/R/build.R
+++ b/R/build.R
@@ -39,7 +39,7 @@ roxygen_and_build = function(
   suppressMessages(roxygenize(pkg, ...))
   if (reformat) {
     message('Reformatting usage and examples')
-    for (f in rd.list) reformat_code(f)
+    for (f in rd.list[-1]) reformat_code(f)
   }
   if (!build) return()
   desc = file.path(pkg, 'DESCRIPTION')


### PR DESCRIPTION
I happened to find Rd2roxigen will delete useDynLib or other lines other than those have export in NAMESPACE file. It would be great if you could add useDynLib as a keyword when parsing NAMESPACE in reformat_code(). Although I don't think people need to reformat a NAMESPACE file indeed.
