### PR TITLE
Fix regex for function names w/metacharacters

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rd2roxygen
 Type: Package
 Title: Convert Rd to 'Roxygen' Documentation
-Version: 1.14.1.1
+Version: 1.14.2
 Authors@R: c(
     person("Hadley", "Wickham", role = "aut"),
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rd2roxygen
 Type: Package
 Title: Convert Rd to 'Roxygen' Documentation
-Version: 1.14.1
+Version: 1.14.1.1
 Authors@R: c(
     person("Hadley", "Wickham", role = "aut"),
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # CHANGES IN Rd2roxygen VERSION 1.15
 
+- Conversion fails if function name contains a regex metacharacter (thanks, @joshuaulrich, #32).
 
 # CHANGES IN Rd2roxygen VERSION 1.14
 

--- a/R/rd2roxygen.R
+++ b/R/rd2roxygen.R
@@ -207,7 +207,7 @@ Rd2roxygen = function(pkg, nomatch, usage = FALSE) {
     for (i in tryf) {
       r = file.path(R.dir, i)
       idx = grep(sprintf('^[[:space:]]*(`|"|\'|)(%s)(\\1)[[:space:]]*(<-|=)',
-                          gsub('\\.', '\\\\.', fname)),
+                          gsub('([][{}()+*^$|?.])', '\\\\\\1', fname)),
                   (r.Rd = readLines(r, warn = FALSE)))
       message('  ', i, ': ', appendLF = FALSE)
       message(ifelse(length(idx), paste('line', idx), 'not found'))


### PR DESCRIPTION
Rd2roxygen() throws an error if the function name contains a regex metacharacter (e.g. "[.data.frame") because the function name is inserted directly into the grep() regular expression.

This commit escapes all regex metacharacters. Fixes #32.