### PR TITLE
Include \R macro in output

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -22,11 +22,16 @@ reconstruct = function(rd) {
                      '}', sep = "", collapse = ""))
       } else if (length(rd) == 0) return(tag(rd))
     }
-    special = tag(rd) == toupper(tag(rd))
-    singles = tag(rd) %in% c('\\tab', '\\cr')
-    prefix = ifelse(special, "",
-                     paste(tag(rd), ifelse(singles, "", "{"), sep = ""))
-    suffix = ifelse(special, "", ifelse(singles, "", "}"))
+
+    special = tag(rd) == toupper(tag(rd)) && tag(rd) != '\\R'
+    if (is.null(tag(rd)) || special) {
+      prefix = ""
+      suffix = ""
+    } else {
+      singles = tag(rd) %in% c('\\tab', '\\cr', '\\R')
+      prefix = paste0(tag(rd), ifelse(singles, "", "{"))
+      suffix = ifelse(singles, "", "}")
+    }
     paste(prefix, paste(sapply(rd, reconstruct), collapse = ""), suffix,
           sep = "")
   } else {


### PR DESCRIPTION
The test for "special" macros in reconstruct() gave a false-positive for "\\R" when "\\R" should be treated like "\\cr". This caused reconstruct() to omit the "\\R" in the roxygen comments.

Add test for NULL tags. Without this test `tag(rd) != "\\R"` and `tag(rd) == toupper(tag(rd))` are both logical(0). The result of `logical(0) && logical(0)` is NA, and ifelse() returns NA if the test argument is NA. So both the prefix and suffix would contain NA.

Fixes #34.